### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+topline (0.4-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 23 Jun 2021 07:03:38 -0000
+
 topline (0.4-1) unstable; urgency=medium
 
   * New upstream bugfixes:

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ topline (0.4-2) UNRELEASED; urgency=medium
     Repository-Browse.
   * Use canonical URL in Vcs-Git.
   * Update standards version to 4.5.1, no changes needed.
+  * Avoid explicitly specifying -Wl,--as-needed linker flag.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 23 Jun 2021 07:03:38 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ topline (0.4-2) UNRELEASED; urgency=medium
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
   * Use canonical URL in Vcs-Git.
+  * Update standards version to 4.5.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 23 Jun 2021 07:03:38 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ topline (0.4-2) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Use canonical URL in Vcs-Git.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 23 Jun 2021 07:03:38 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: https://github.com/kilobyte/topline
 Vcs-Browser: https://github.com/kilobyte/topline/tree/debian
-Vcs-Git: https://github.com/kilobyte/topline -b debian
+Vcs-Git: https://github.com/kilobyte/topline.git -b debian
 
 Package: topline
 Architecture: linux-any

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: utils
 Priority: optional
 Maintainer: Adam Borowski <kilobyte@angband.pl>
 Build-Depends: debhelper-compat (= 12)
-Standards-Version: 4.5.0
+Standards-Version: 4.5.1
 Rules-Requires-Root: no
 Homepage: https://github.com/kilobyte/topline
 Vcs-Browser: https://github.com/kilobyte/topline/tree/debian

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,6 @@
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 export DEB_CFLAGS_MAINT_APPEND  = -Wall
-export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
 %:
 	dh $@

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/kilobyte/topline/issues
+Bug-Submit: https://github.com/kilobyte/topline/issues/new
+Repository: https://github.com/kilobyte/topline.git
+Repository-Browse: https://github.com/kilobyte/topline


### PR DESCRIPTION
Fix some issues reported by lintian

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))

* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical))

* Update standards version to 4.5.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

* Avoid explicitly specifying -Wl,--as-needed linker flag. ([debian-rules-uses-as-needed-linker-flag](https://lintian.debian.org/tags/debian-rules-uses-as-needed-linker-flag))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/topline/bc0f0df9-da18-462d-9714-ec7acdbcd1fe.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/bc0f0df9-da18-462d-9714-ec7acdbcd1fe/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/bc0f0df9-da18-462d-9714-ec7acdbcd1fe/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/bc0f0df9-da18-462d-9714-ec7acdbcd1fe/diffoscope)).
